### PR TITLE
Add option `MONGO_USERNAME`, `MONGO_PASSWORD`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,16 @@ docker run -d \
     -e 'BACKUP_FILE_NAME=express' \     # custom name for backup archive
     tenorok/mongodumper
 ```
+
+### Option `MONGO_USERNAME`, `MONGO_PASSWORD`
+
+If your mongodb need user and password to access, you need set them in your environment.
+
+```bash
+docker run -d \
+    -v /path/to/my-folder:/backup \
+    --link my-mongo-container:mongo \
+    -e 'MONGO_USERNAME=root' \          # mongo -u $MONGO_USERNAME
+    -e 'MONGO_PASSWORD=rootpassword' \  # mongo -p $MONGO_PASSWORD
+    tenorok/mongodumper
+```

--- a/backup.sh
+++ b/backup.sh
@@ -13,7 +13,11 @@ else
     FILE="$DIR/$DATE"
 fi
 
-command="mongodump -h $MONGO_PORT_27017_TCP_ADDR -p $MONGO_PORT_27017_TCP_PORT --gzip"
+if [[ $MONGO_USERNAME ]]; then
+    command="mongodump -u $MONGO_USERNAME -p $MONGO_PASSWORD -h $MONGO_PORT_27017_TCP_ADDR --port $MONGO_PORT_27017_TCP_PORT --gzip"
+else
+    command="mongodump -h $MONGO_PORT_27017_TCP_ADDR --port $MONGO_PORT_27017_TCP_PORT --gzip"
+fi
 
 # All output of mongodump is stderr, therefore filter the errors manually.
 filter_errors="2> >(grep -i 'failed\|error')"


### PR DESCRIPTION
When I use `mongo --auth` to run my mongo container, I need auth option to access mongo.
Thus, I added this option, please merge it.
Thanks!